### PR TITLE
Fix/kotest multiplatform plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ buildscript {
             .getByName("libs") as org.gradle.accessors.dm.LibrariesForLibs
         classpath(libs.android.gradlePlugin)
         classpath(libs.apollo.gradlePlugin)
+        classpath(libs.kotest.gradlePlugin)
         classpath(libs.kotlin.gradlePlugin)
         classpath(libs.npmPublish.gradlePlugin)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ minSdkVersion = "23"
 # gradlePlugin versions
 androidGradlePlugin = "7.0.4"
 apollo = "3.1.0"
+kotest = "5.1.0"
 kotlin = "1.6.10"
 
 # Other versions sorted alphabetically
@@ -19,6 +20,7 @@ npmPublish = "2.1.2"
 # Gradle plugins
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
 apollo-gradlePlugin = { module = "com.apollographql.apollo3:apollo-gradle-plugin", version.ref = "apollo" }
+kotest-gradlePlugin = { module = "io.kotest:kotest-framework-multiplatform-plugin-gradle", version.ref = "kotest" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 npmPublish-gradlePlugin = { module = "dev.petuska.npm.publish:dev.petuska.npm.publish.gradle.plugin", version.ref = "npmPublish" }
 
@@ -32,6 +34,8 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+
+kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     kotlin("multiplatform")
     id("com.android.library")
     id("dev.petuska.npm.publish")
+    id("io.kotest.multiplatform")
 }
 
 kotlin {
@@ -40,10 +41,10 @@ kotlin {
             dependencies {
                 implementation(libs.coroutines.test)
                 implementation(libs.koin.test)
+                implementation(libs.kotest.assertions)
 
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-                implementation("io.kotest:kotest-assertions-core:5.1.0")
             }
         }
 

--- a/shared/src/commonTest/kotlin/com/hedvig/embarkx/store/EmbarkStoreTest.kt
+++ b/shared/src/commonTest/kotlin/com/hedvig/embarkx/store/EmbarkStoreTest.kt
@@ -1,10 +1,12 @@
 package com.hedvig.embarkx.store
 
 import io.kotest.matchers.shouldBe
+import kotlin.js.JsName
 import kotlin.test.Test
 
 class EmbarkStoreTest {
     @Test
+    @JsName("should_be_able_to_put_a_key_then_get_it")
     fun `should be able to put a key then get it`() {
         val store = EmbarkStore()
 
@@ -13,12 +15,14 @@ class EmbarkStoreTest {
     }
 
     @Test
+    @JsName("should_return_null_when_getting_a_key_that_does_not_exist")
     fun `should return null when getting a key that does not exist`() {
         val store = EmbarkStore()
         store.get("foo") shouldBe null
     }
 
     @Test
+    @JsName("should_remove_values_when_rolling_back")
     fun `should remove values when rolling back`() {
         val store = EmbarkStore()
 
@@ -30,6 +34,7 @@ class EmbarkStoreTest {
     }
 
     @Test
+    @JsName("should_be_able_to_get_value_from_prefill_even_if_value_has_been_rolled_back")
     fun `should be able to get value from prefill even if value has been rolled back`() {
         val store = EmbarkStore()
 

--- a/shared/src/commonTest/kotlin/com/hedvig/embarkx/util/StackTest.kt
+++ b/shared/src/commonTest/kotlin/com/hedvig/embarkx/util/StackTest.kt
@@ -3,21 +3,25 @@ package com.hedvig.embarkx.util
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
+import kotlin.js.JsName
 
 class StackTest {
     @Test
+    @JsName("should_throw_when_popping_an_empty_stack")
     fun `should throw when popping an empty stack`() {
         val stack = Stack<Unit>()
         shouldThrow<EmptyStackException> { stack.pop() }
     }
 
     @Test
+    @JsName("should_throw_when_peeking_an_empty_stack")
     fun `should throw when peeking an empty stack`() {
         val stack = Stack<Unit>()
         shouldThrow<EmptyStackException> { stack.peek() }
     }
 
     @Test
+    @JsName("should_return_latest_pushed_value_when_peeking")
     fun `should return latest pushed value when peeking`() {
         val stack = Stack<String>()
 
@@ -27,6 +31,7 @@ class StackTest {
     }
 
     @Test
+    @JsName("should_return_latest_pushed_value_when_popping")
     fun `should return latest pushed value when popping`() {
         val stack = Stack<String>()
 
@@ -36,7 +41,8 @@ class StackTest {
     }
 
     @Test
-    fun `when multiple items are pushed, they are returned in order when popping them`() {
+    @JsName("when_multiple_items_are_pushed_they_are_returned_in_order_when_popping_them")
+    fun `when multiple items are pushed they are returned in order when popping them`() {
         val stack = Stack<String>()
 
         stack.push("foo")


### PR DESCRIPTION
Running ./gradlew shared:allTests failed with the addition of kotest by deafault with the error:
`> Failed to execute all tests:
  :shared:iosSimulatorArm64Test: java.lang.IllegalStateException: command '/usr/bin/xcrun' exited with errors (exit code: 86)`
  
Kotest provides a gradle plugin to enable multiplatform functionality as shown [here](https://plugins.gradle.org/plugin/io.kotest.multiplatform) and [here](https://plugins.gradle.org/plugin/io.kotest.multiplatform) this seems to make the tests run again!