### PR TITLE
feat: expose embark store

### DIFF
--- a/shared/src/commonMain/kotlin/com/hedvig/embarkx/store/EmbarkStore.kt
+++ b/shared/src/commonMain/kotlin/com/hedvig/embarkx/store/EmbarkStore.kt
@@ -1,7 +1,9 @@
 package com.hedvig.embarkx.store
 
 import com.hedvig.embarkx.util.Stack
+import kotlin.js.JsExport
 
+@JsExport
 class EmbarkStore {
     private val versions = Stack<Map<String, String?>>().apply { push(emptyMap()) }
     private val stage = mutableMapOf<String, String?>()


### PR DESCRIPTION
This adds shared EmbarkStore into npm package so I can test it on `embark` package. 